### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/week_10/exercise/EX_2_Financial_Analyst_Agent_using_AutoGen_and_Prompt_Templates.ipynb
+++ b/week_10/exercise/EX_2_Financial_Analyst_Agent_using_AutoGen_and_Prompt_Templates.ipynb
@@ -20,7 +20,7 @@
         "\n",
         "1.  **Environment Setup:**\n",
         "    * Create a new Python virtual environment.\n",
-        "        * Install necessary libraries: `pyautogen`, `pandas`, `yfinance` (for stock data), `matplotlib`, `seaborn`, `python-dotenv`.\n",
+        "        * Install necessary libraries: `ag2`, `pandas`, `yfinance` (for stock data), `matplotlib`, `seaborn`, `python-dotenv`.\n",
         "        * Provide a `requirements.txt` file.\n",
         "\n",
         "2.  **LLM API Key Configuration:**\n",

--- a/week_7/exercise/EX_1_Create_AutoGen_Chat_Agents_with_User_Proxy_and_Assistant_Roles.ipynb
+++ b/week_7/exercise/EX_1_Create_AutoGen_Chat_Agents_with_User_Proxy_and_Assistant_Roles.ipynb
@@ -63,7 +63,7 @@
       "source": [
         "### Instructions:\n",
         "1.  **LLM Access**: You will need access to an LLM API. **OpenAI's models (e.g., GPT-4o, GPT-4, GPT-3.5-turbo)** are recommended for their robust function calling capabilities, which AutoGen leverages heavily. You can also use local LLMs via `ollama` or `lmstudio` if configured correctly (see AutoGen docs for details).\n",
-        "2.  **Environment Setup**: Install the necessary Python library: `pip install pyautogen`.\n",
+        "2.  **Environment Setup**: Install the necessary Python library: `pip install ag2`.\n",
         "3.  **API Key**: Securely handle your API key. It's best practice to load it from an environment variable or a configuration file (like `OAI_CONFIG_LIST`). For simplicity in this assignment, we'll demonstrate using `os.environ`.\n",
         "4.  **Jupyter Notebook**: All your code, outputs, observations, and analysis must be documented in this Jupyter Notebook.\n",
         "5.  **Task Scenario**: The agents will collaborate to solve a simple Python coding problem or a knowledge-based query.\n",
@@ -99,7 +99,7 @@
       "cell_type": "markdown",
       "source": [
         "### Task 1.1: Install AutoGen\n",
-        "Ensure `pyautogen` is installed in your environment."
+        "Ensure `ag2` is installed in your environment."
       ],
       "metadata": {
         "id": "Qm0XUAI5bLs2"
@@ -110,7 +110,7 @@
       "cell_type": "code",
       "source": [
         "# Install AutoGen (if not already installed)\n",
-        "# !pip install pyautogen --quiet\n",
+        "# !pip install ag2 --quiet\n",
         "\n",
         "import autogen\n",
         "import os\n",


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
